### PR TITLE
Enable lm to work with Circuitscape 4.0.5

### DIFF
--- a/toolbox/scripts/circuitscape_master.py
+++ b/toolbox/scripts/circuitscape_master.py
@@ -10,7 +10,8 @@ Numpy
 
 """
 
-import os.path as path
+import os
+from os import path
 import shutil
 import sys
 
@@ -37,36 +38,22 @@ def circuitscape_master(argv=None):
     # gwarn = arcpy.AddWarning
 
     if argv is None:
-        argv = sys.argv    
+        argv = sys.argv
+
+    argv.append(get_cs_path())  # Add Circuitscape path
     
     cfg.configure(cfg.TOOL_CS, argv)
     gp = cfg.gp
-
-    
+       
     try:
         lu.create_dir(cfg.LOGDIR)
         lu.create_dir(cfg.MESSAGEDIR)
-        cfg.logFilePath=lu.create_log_file(cfg.MESSAGEDIR, cfg.TOOL, 
-                                           cfg.PARAMS) 
+        cfg.logFilePath = lu.create_log_file(cfg.MESSAGEDIR, cfg.TOOL, 
+                                           cfg.PARAMS)
 
-        CSPATH = lu.get_cs_path()
-        if CSPATH == None:
-            msg = ('Cannot find an installation of Circuitscape 3.5.5'
-                    '\nor greater in your Program Files directory.')
-            arcpy.AddError(msg)
-            lu.write_log(msg)
-            exit(1)
-            
-        try:
-            csDir, fn = path.split(CSPATH)
-            if 'flush' not in open(path.join(csDir,'cs_compute.py')).read():
-                lu.warn('\n---------------------------------------------')
-                lu.warn('Your version of Circuitscape is out of date. ')
-                lu.warn('---------------------------------------------\n')
-                lu.warn('Please get the latest from www.circuitscape.org.')
-                lu.warn('The new version interacts more smoothly with ArcMap.')
-                gprint('Proceeding...\n')
-        except: pass
+        if cfg.CSPATH is None:
+            lu.raise_error("Cannot find an installation of Circuitscape"
+                           "\nin your Program Files directory.")  
         
         lu.print_drive_warning()
         # Check core ID field.
@@ -175,8 +162,18 @@ def circuitscape_master(argv=None):
         lu.exit_with_geoproc_error(_SCRIPT_NAME)
 
     # Return any PYTHON or system specific errors
-    except:
+    except Exception:
         lu.exit_with_python_error(_SCRIPT_NAME)
+
+
+def get_cs_path():
+    """Return path to Circuitscape installation."""
+    env_list = ["ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"]
+
+    for i in env_list:
+        cs_app_path = path.join(os.environ[i], "Circuitscape\\cs_run.exe")
+        if path.exists(cs_app_path):
+            return cs_app_path
 
 
 if __name__ == "__main__":

--- a/toolbox/scripts/lm_config.py
+++ b/toolbox/scripts/lm_config.py
@@ -302,10 +302,11 @@ def config_lp(config, arg):
 
 def config_circuitscape(config, arg):
     """Configure global variables for Circuitscape."""
+    config.CSPATH = arg[-1]  # Path to Circuitscape
     config.COREFC = arg[2]
     config.COREFN = arg[3]
 
-    if len(arg) == 4:
+    if len(arg) == 5:
         config.DOCENTRALITY = True
         config.DOPINCH = False
         config.CWDCUTOFF = 0

--- a/toolbox/scripts/s7_centrality.py
+++ b/toolbox/scripts/s7_centrality.py
@@ -10,11 +10,9 @@ Numpy
 """
 
 import os.path as path
-import subprocess
 
 import arcpy
 import numpy as npy
-from lm_retry_decorator import retry
 
 from lm_config import tool_env as cfg
 import lm_util as lu
@@ -48,8 +46,6 @@ def STEP7_calc_centrality():
         # Remove lcp shapefile from this step if run previously
         lcpShapefile = path.join(cfg.DATAPASSDIR, "lcpLines_s7.shp")
         lu.delete_data(lcpShapefile)
-
-        csPath = lu.get_cs_path()
 
         invalidFNs = ['fid','id','oid','shape']
         if cfg.COREFN.lower() in invalidFNs:
@@ -144,9 +140,8 @@ def STEP7_calc_centrality():
 
         write_graph(options['habitat_file'] ,graphList)
         gprint('\nCalculating current flow centrality using Circuitscape...')
-        #subprocess.call([csPath, outConfigFile], shell=True)   
         
-        memFlag = call_circuitscape(csPath, outConfigFile)        
+        memFlag = lu.call_circuitscape(cfg.CSPATH, outConfigFile)        
         
         outputFN = 'Circuitscape_network_branch_currents_cum.txt'
         currentList = path.join(OUTCENTRALITYDIR, outputFN)
@@ -155,8 +150,7 @@ def STEP7_calc_centrality():
             write_graph(options['habitat_file'] ,graphList)
             gprint('\nCalculating current flow centrality using Circuitscape '
                    '(2nd try)...')
-            # subprocess.call([csPath, outConfigFile], shell=True)  
-            memFlag = call_circuitscape(csPath, outConfigFile)                    
+            memFlag = lu.call_circuitscape(cfg.CSPATH, outConfigFile)                    
             if not arcpy.Exists(currentList):
                 lu.dashline(1)
                 msg = ('ERROR: No Circuitscape output found.\n'
@@ -279,62 +273,4 @@ def make_graph_from_list(graphList):
     except:
         lu.dashline(1)
         gprint('****Failed in step 7. Details follow.****')
-        lu.exit_with_python_error(_SCRIPT_NAME)
-
-        
-@retry(10)
-def call_circuitscape(CSPATH, outConfigFile):
-    randomerror()
-    memFlag = False
-    failFlag = False
-    gprint('     Calling Circuitscape:')
-    proc = subprocess.Popen([CSPATH, outConfigFile],
-                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT, 
-                           shell=True)
-    while proc.poll() is None:
-        output = proc.stdout.readline()
-
-        if 'Traceback' in output:
-            gprint("\nCircuitscape failed.")
-            failFlag = True
-            if 'memory' in output:
-                memFlag = True
-        if ('Processing' not in output and 'laplacian' not in output and 
-                'node_map' not in output and (('--' in output) or 
-                ('sec' in output) or (failFlag == True))):
-            gprint("      " + output.replace("\r\n",""))                
-    
-    # Catch any output lost if process closes too quickly
-    output=proc.communicate()[0]
-    for line in output.split('\r\n'):
-        if 'Traceback' in line:
-            gprint("\nCircuitscape failed.")
-            if 'memory' in line:
-                memFlag = True
-        if ('Processing' not in line and 'laplacian' not in line and 
-                'node_map' not in line and (('--' in line) or 
-                ('sec' in line) or (failFlag == True))):
-           gprint("      " + str(line))#.replace("\r\n","")))              
-    return memFlag
-
-
-def randomerror():
-    """ Used to test error recovery.
-
-    """
-    generateError = False # Set to True to create random errors
-    gprint=lu.gprint
-    if generateError:
-        gprint('\n***Rolling dice for random error***')
-        import random
-        test = random.randrange(2, 5)
-        if test == 2:
-            gprint('Creating artificial ArcGIS error')
-            arcpy.MosaicToNewRaster_management(
-                            "rasterString","mosaicDir","mosFN", "", 
-                            "32_BIT_FLOAT", "gp.cellSize", "1", "MINIMUM", 
-                            "MATCH")
-        elif test == 3:
-            gprint('Creating artificial python error')
-            artificialPythonError
-    return              
+        lu.exit_with_python_error(_SCRIPT_NAME)      


### PR DESCRIPTION
Circuitscape no longer ships with  'cs_compute.py' so do not search for
it. Assume Circuitscape will be version 3.5.5 or greater.

Also, refactor code to reduce duplication and redundancy.

Does not address [Circuitscape array problem](https://github.com/Circuitscape/Circuitscape/pull/88).