### PR TITLE
Changed float data type syntax according to new version of numpy

### DIFF
--- a/toolbox/scripts/lm_util.py
+++ b/toolbox/scripts/lm_util.py
@@ -891,7 +891,7 @@ def update_lcp_shapefile(linktable, lastStep, thisStep):
         if thisStep > 5:
             linkTableTemp = linktable
         else:
-            extraCols = npy.zeros((numLinks, 3), dtype="float64")
+            extraCols = npy.zeros((numLinks, 3), dtype=npy.float64)
             linkTableTemp = npy.append(linktable, extraCols, axis=1)
             del extraCols
             linkTableTemp[:, cfg.LTB_LCPLEN] = -1
@@ -1095,10 +1095,10 @@ def check_stars(D, star): # same as gapdt
 def load_link_table(linkTableFile):
     """Reads link table created by previous step """
     try:
-        linkTable1 = npy.loadtxt(linkTableFile, dtype='Float64',
+        linkTable1 = npy.loadtxt(linkTableFile, dtype=npy.float64,
                              comments='#', delimiter=',')
         if len(linkTable1) == linkTable1.size:  # Just one connection
-            linktable = npy.zeros((1, len(linkTable1)), dtype='Float64')
+            linktable = npy.zeros((1, len(linkTable1)), dtype=npy.float64)
             linktable[:, 0:len(linkTable1)] = linkTable1[0:len(linkTable1)]
         else:
             linktable = linkTable1
@@ -1404,7 +1404,7 @@ def write_link_maps(linkTableFile, step):
         coreLinks = linktable
 
         # create coreCoords array, with geographic centers of cores
-        coreCoords = npy.zeros(pointArray.shape, dtype='float64')
+        coreCoords = npy.zeros(pointArray.shape, dtype=npy.float64)
         coreCoords[:, 0] = pointArray[:, 2]
         coreCoords[:, 1] = pointArray[:, 0]
         coreCoords[:, 2] = pointArray[:, 1]

--- a/toolbox/scripts/s2_buildNetwork.py
+++ b/toolbox/scripts/s2_buildNetwork.py
@@ -53,10 +53,10 @@ def STEP2_build_network():
         else:
             eucdist_file = cfg.S2EUCDISTFILE
 
-        eucDists_in = npy.loadtxt(eucdist_file, dtype='Float64', comments='#')
+        eucDists_in = npy.loadtxt(eucdist_file, dtype=npy.float64, comments='#')
 
         if eucDists_in.size == 3:  # If just one line in file
-            eucDists = npy.zeros((1, 3), dtype='Float64')
+            eucDists = npy.zeros((1, 3), dtype=npy.float64)
             eucDists[0, :] = eucDists_in
             numDists = 1
 

--- a/toolbox/scripts/s3_calcCwds.py
+++ b/toolbox/scripts/s3_calcCwds.py
@@ -269,7 +269,7 @@ def STEP3_calc_cwds():
         if rerun:
             # saved linktable replaces the one now in memory
             linkTable = lu.load_link_table(savedLinkTableFile)
-            coresToMapSaved = npy.loadtxt(coreListFile, dtype='Float64',
+            coresToMapSaved = npy.loadtxt(coreListFile, dtype=npy.float64,
                                           comments='#', delimiter=',')
             startIndex = coresToMapSaved[0] # Index of core where we left off
             del coresToMapSaved

--- a/toolbox/scripts/s7_centrality.py
+++ b/toolbox/scripts/s7_centrality.py
@@ -77,7 +77,7 @@ def STEP7_calc_centrality():
 
         if linkTable.shape[1] < 16: # If linktable has no entries from prior
                                     # centrality or pinchpint analyses
-            extraCols = npy.zeros((numLinks, 6), dtype="float64")
+            extraCols = npy.zeros((numLinks, 6), dtype=npy.float64)
             linkTable = linkTable[:,0:10]
             linkTable = npy.append(linkTable, extraCols, axis=1)
             linkTable[:, cfg.LTB_LCPLEN] = -1
@@ -124,7 +124,7 @@ def STEP7_calc_centrality():
         LT = lu.delete_row(linkTable, delRowsVector)
         del delRows
         del delRowsVector
-        graphList = npy.zeros((LT.shape[0],3), dtype="float64")
+        graphList = npy.zeros((LT.shape[0],3), dtype=npy.float64)
         graphList[:,0] = LT[:,cfg.LTB_CORE1]
         graphList[:,1] = LT[:,cfg.LTB_CORE2]
         graphList[:,2] = LT[:,cfg.LTB_CWDIST]
@@ -152,7 +152,7 @@ def STEP7_calc_centrality():
 
 
         currents = load_graph(currentList,graphType='graph/network',
-                              datatype='float64')
+                              datatype=npy.float64)
 
         numLinks = currents.shape[0]
         for x in range(0,numLinks):
@@ -167,7 +167,7 @@ def STEP7_calc_centrality():
         coreCurrentFN = 'Circuitscape_network_node_currents_cum.txt'
         nodeCurrentList = path.join(OUTCENTRALITYDIR, coreCurrentFN)
         nodeCurrents = load_graph(nodeCurrentList,graphType='graph/network',
-                              datatype='float64')
+                              datatype=npy.float64)
 
         numNodeCurrents = nodeCurrents.shape[0]
         rows = arcpy.UpdateCursor(coreCopy)
@@ -232,10 +232,10 @@ def load_graph(filename,graphType,datatype):
         raise RuntimeError('File "'  + filename + '" does not exist')
     f = open(filename, 'r')
     try:
-        graphObject = npy.loadtxt(filename, dtype = 'Float64', comments='#')
+        graphObject = npy.loadtxt(filename, dtype=npy.float64, comments='#')
     except Exception:
         try:
-            graphObject = npy.loadtxt(filename, dtype = 'Float64',
+            graphObject = npy.loadtxt(filename, dtype=npy.float64,
                                       comments='#', delimiter=',')
         except Exception:
             raise RuntimeError('Error reading',type,

--- a/toolbox/scripts/s8_pinchpoints.py
+++ b/toolbox/scripts/s8_pinchpoints.py
@@ -86,7 +86,7 @@ def STEP8_calc_pinchpoints():
 
         if linkTable.shape[1] < 16: # If linktable has no entries from prior
                                     # centrality or pinchpint analyses
-            extraCols = npy.zeros((numLinks, 6), dtype="float64")
+            extraCols = npy.zeros((numLinks, 6), dtype=npy.float64)
             linkTable = linkTable[:,0:10]
             linkTable = npy.append(linkTable, extraCols, axis=1)
             linkTable[:, cfg.LTB_LCPLEN] = -1
@@ -318,7 +318,7 @@ def STEP8_calc_pinchpoints():
 
                 resistancesFile = path.join(OUTCIRCUITDIR,resistancesFN)
                 resistances = npy.loadtxt(resistancesFile,
-                                          dtype = 'Float64', comments='#')
+                                          dtype=npy.float64, comments='#')
 
                 resistance = float(arcpy.env.cellSize) * resistances[2]
                 linkTable[link,cfg.LTB_EFFRESIST] = resistance


### PR DESCRIPTION
Converting distance data to NumPy array with `dtype = ‘Float64’` is raising the error in ArcGIS Pro as Pro uses the latest version of Numpy.  Replacing `dtype = 'Float64'` with `dtype = np.float64` (new syntax) solved the issue and this syntax works well with the old version of NumPy in ArcGIS.