### PR TITLE
Updating subprocess module syntax according to python3

### DIFF
--- a/toolbox/scripts/cc_config.py
+++ b/toolbox/scripts/cc_config.py
@@ -8,7 +8,6 @@ Classes:
 """
 
 import os
-import subprocess
 import sys
 
 import lm_util_config as util
@@ -43,12 +42,6 @@ class ClimateConfig(object):
         self.gpath = (''.join([os.path.join(cc_env.gisbase, gpath) + os.pathsep
                                for gpath in [r'mysys\bin', 'bin', 'extrabin',
                                              'lib', r'etc\python', 'etc']]))
-
-        # Overwrite default startup subprocess variables to insure the console
-        # window is hidden. This is necessary as functions within the GRASS
-        # scripting library open subprocesses with the console window open.
-        subprocess.STARTUPINFO.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        subprocess.STARTUPINFO.wShowWindow = subprocess.SW_HIDE
 
         # Tool settings
         self.min_euc_dist = float(arg[7])  # Min distance between core pairs

--- a/toolbox/scripts/cc_grass_cwd.py
+++ b/toolbox/scripts/cc_grass_cwd.py
@@ -3,6 +3,7 @@
 """Create CWD and Back rasters using GRASS GIS r.walk function."""
 
 import os
+import subprocess
 
 import arcpy
 
@@ -178,6 +179,9 @@ def start_grass_cmd(*args, **kwargs):
 
     Returns Popen object
     """
+    startupinfo = hideprocess()
+    kwargs['startupinfo'] = startupinfo
+
     kwargs['stdout'] = grass.PIPE
     kwargs['stderr'] = grass.PIPE
     return grass.start_command(*args, **kwargs)
@@ -202,3 +206,13 @@ def write_grass_cmd(*args, **kwargs):
     kwargs['stdin'] = grass.PIPE
     return_ps = start_grass_cmd(*args, **kwargs)
     chk_stderr(return_ps.communicate(input=stdin.encode())[1])
+
+
+def hideprocess():
+    # Overwrite default startup subprocess variables to insure the console
+    # window is hidden. This is necessary as functions within the GRASS
+    # scripting library open subprocesses with the console window open.
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    startupinfo.wShowWindow = subprocess.SW_HIDE
+    return startupinfo


### PR DESCRIPTION
ArcGIS Pro 2.8.1 is raising error due to changes in the python (3) and subprocess module versions. The issue opened at #147.  I have modified the code that works with both ArcGIS and ArcGIS Pro > 2.8.  But the issue after merging this code will be the GRASS GIS window will open when initializing the works space (instead of hiding and run the process in the backend), this has to impove.