### PR TITLE
Use floor division for 3.x compatibility

### DIFF
--- a/toolbox/scripts/s6_barriers.py
+++ b/toolbox/scripts/s6_barriers.py
@@ -130,7 +130,7 @@ def step6_calc_barriers():
                        str(map_units) + ' radius analysis scale.')
                 focal_dir_base_name = dir2
 
-                cp100 = cores_to_process.astype('int32') / 100
+                cp100 = cores_to_process.astype('int32') // 100
                 ind = npy.where(cp100 > 0)
                 dir_nums = npy.unique(cp100[ind])
                 for dir_num in dir_nums:


### PR DESCRIPTION
Use the floor division operator (//) to truncate fractional remainders down to their floor in both Python 2 and Python 3. See [Python - Classic, Floor, and True Division](http://www.java2s.com/example/python-book/classic-floor-and-true-division.html). Resolves directory issue raised by Aiman Duckworth in email.


