### PR TITLE
Replace time.clock with time.perf_counter

### DIFF
--- a/toolbox/scripts/iterate_barriers.py
+++ b/toolbox/scripts/iterate_barriers.py
@@ -7,7 +7,12 @@ for max ROI.
 import sys
 import os
 import shutil
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -28,7 +33,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv  # Get parameters from ArcGIS tool dialog
 
-    start_time = time.clock()
+    start_time = perf_counter()
 
     # USER SETTINGS ######################################################
 
@@ -180,7 +185,7 @@ def main(argv=None):
         all_restored_areas_ras = ''
 
         for cur_iter in range(1, iterations + 1):
-            start_time1 = time.clock()
+            start_time1 = perf_counter()
 
             # Some env settings get changed by linkage mapper and must be
             # reset here

--- a/toolbox/scripts/lm_util.py
+++ b/toolbox/scripts/lm_util.py
@@ -6,15 +6,18 @@ import os
 import sys
 import subprocess
 from datetime import datetime as dt
-import time
 import traceback
 import platform
 
-# Support configparser in Python 2 and 3
+# Add support for Python 2. Try to import Python 3 modules first.
 try:
-    from configparser import RawConfigParser  # Python 3
+    from configparser import RawConfigParser
 except ImportError:
-    from ConfigParser import RawConfigParser  # Python 2
+    from ConfigParser import RawConfigParser
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import shutil
 import gc
@@ -327,7 +330,7 @@ def run_time(stime):
 
 def elapsed_time(start_time):
     """Print elapsed time given a start time and return a new start time."""
-    now = time.clock()
+    now = perf_counter()
     hours, minutes, seconds = s2hhmmss(now - start_time)
     msg = "Task took:"
     if minutes == 0:
@@ -419,7 +422,7 @@ def get_adj_using_shift_method(alloc):
     arcpy.env.workspace = cfg.SCRATCHDIR
 
     gprint('Calculating adjacencies crossing allocation boundaries...')
-    start_time = time.clock()
+    start_time = perf_counter()
     arcpy.Shift_management(alloc, "alloc_r", posShift, "0")
 
     alloc_r = "alloc_r"

--- a/toolbox/scripts/s1_getAdjacencies.py
+++ b/toolbox/scripts/s1_getAdjacencies.py
@@ -8,7 +8,12 @@ cost-weighted distance space
 """
 
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 modules first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -116,7 +121,7 @@ def cwadjacency():
         arcpy.env.extent = arcpy.Describe(cfg.RESRAST).extent
         if cfg.BUFFERDIST is not None:
             # Clip resistance raster using bounding circle
-            start_time = time.clock()
+            start_time = perf_counter()
             arcpy.env.cellSize = arcpy.Describe(cfg.RESRAST).MeanCellHeight
             arcpy.env.extent = arcpy.Describe(cfg.RESRAST).Extent
             bResistance = arcpy.sa.ExtractByMask(cfg.RESRAST, cfg.BNDCIR)
@@ -126,7 +131,7 @@ def cwadjacency():
         else:
             bResistance = cfg.RESRAST
 
-        start_time = time.clock()
+        start_time = perf_counter()
         gprint('Starting cost-weighted distance allocation...')
 
         if cfg.TMAXCWDIST is not None:
@@ -202,7 +207,7 @@ def euadjacency():
         if cfg.BUFFERDIST is not None:
             arcpy.env.extent = arcpy.Describe(cfg.BNDCIR).extent
 
-        start_time = time.clock()
+        start_time = perf_counter()
 
         arcpy.env.scratchWorkspace = cfg.ARCSCRATCHDIR
         outDistanceRaster = path.join(cfg.ADJACENCYDIR, "euc")

--- a/toolbox/scripts/s2_buildNetwork.py
+++ b/toolbox/scripts/s2_buildNetwork.py
@@ -8,7 +8,12 @@ adjacencies of core areas
 """
 
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -313,7 +318,7 @@ def generate_distance_file():
         gprint('There are ' + str(len(adjList)) + ' adjacent core pairs to '
                'process.')
         pctDone = 0
-        start_time = time.clock()
+        start_time = perf_counter()
         for x in range(0, len(adjList)):
 
             pctDone = lu.report_pct_done(x, len(adjList), pctDone)

--- a/toolbox/scripts/s3_calcCwds.py
+++ b/toolbox/scripts/s3_calcCwds.py
@@ -10,7 +10,12 @@ extent of cwd calculations and speed computation.
 
 
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -149,7 +154,7 @@ def STEP3_calc_cwds():
         # Bounding boxes
         if (cfg.BUFFERDIST) is not None:
             # create bounding boxes around cores
-            start_time = time.clock()
+            start_time = perf_counter()
             gprint('Calculating bounding boxes for core areas.')
             extentBoxList = npy.zeros((0,5), dtype='float32')
             for x in range(len(coresToMap)):
@@ -163,7 +168,7 @@ def STEP3_calc_cwds():
         # Bounding circle code
         if cfg.BUFFERDIST is not None:
             # Make a set of circles encompassing core areas we'll be connecting
-            start_time = time.clock()
+            start_time = perf_counter()
             gprint('Calculating bounding circles around potential'
                           ' corridors.')
 
@@ -291,7 +296,7 @@ def STEP3_calc_cwds():
         endIndex = len(coresToMap)
         linkTableMod = linkTable.copy()
         while x < endIndex:
-            startTime1 = time.clock()
+            startTime1 = perf_counter()
             # Modification of linkTable in function was causing problems. so
             # make a copy:
             linkTablePassed = linkTableMod.copy()
@@ -338,7 +343,7 @@ def STEP3_calc_cwds():
         linkTableLogFile = path.join(cfg.LOGDIR, "linkTable_s3.csv")
         lu.write_link_table(linkTable, linkTableLogFile)
 
-        start_time = time.clock()
+        start_time = perf_counter()
         gprint('Creating shapefiles with linework for links...')
         try:
             lu.write_link_maps(outlinkTableFile, step=3)
@@ -429,7 +434,7 @@ def do_cwd_calcs(x, linkTable, coresToMap, lcpLoop, failures):
             arcpy.MakeFeatureLayer_management(
                 cfg.BNDCIRS, "fGlobalBoundingFeat")
 
-            start_time = time.clock()
+            start_time = perf_counter()
             # loop through targets and get bounding circles that
             # contain focal core and target cores
             arcpy.SelectLayerByAttribute_management(
@@ -485,7 +490,7 @@ def do_cwd_calcs(x, linkTable, coresToMap, lcpLoop, failures):
             back_rast = "BACK"
             lu.delete_data(path.join(coreDir, back_rast))
             lu.delete_data(outDistanceRaster)
-            start_time = time.clock()
+            start_time = perf_counter()
 
             # Create raster that just has source core in it
             # Note: this seems faster than setnull with LI grid.
@@ -519,7 +524,7 @@ def do_cwd_calcs(x, linkTable, coresToMap, lcpLoop, failures):
                 else:
                     exec(statement)
 
-        start_time = time.clock()
+        start_time = perf_counter()
         # Extract cost distances from source core to target cores
         # Fixme: there will be redundant calls to b-a when already
         # done a-b

--- a/toolbox/scripts/s4_refineNetwork.py
+++ b/toolbox/scripts/s4_refineNetwork.py
@@ -13,7 +13,12 @@ nearest neighboring cluster
 # Could use previous (now discarded) combo code to mosaic CWDS if wanted.
 
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -205,7 +210,7 @@ def STEP4_refine_network():
         linkTableLogFile = path.join(cfg.LOGDIR, "linkTable_s4.csv")
         lu.write_link_table(linkTable, linkTableLogFile)
 
-        start_time = time.clock()
+        start_time = perf_counter()
         lu.update_lcp_shapefile(linkTable, lastStep=3, thisStep=4)
         start_time = lu.elapsed_time(start_time)
 

--- a/toolbox/scripts/s5_calcLccs.py
+++ b/toolbox/scripts/s5_calcLccs.py
@@ -9,7 +9,12 @@ pairs specified in linkTable and cwd layers
 
 import json
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -142,7 +147,7 @@ def calc_lccs(normalize):
                 continue
 
             linkCount = linkCount + 1
-            start_time = time.clock()
+            start_time = perf_counter()
 
             linkId = str(int(linkTable[x, cfg.LTB_LINKID]))
 
@@ -249,7 +254,7 @@ def calc_lccs(normalize):
                         if not tryAgain:
                             exec(statement)
                     else: break
-            endTime = time.clock()
+            endTime = perf_counter()
             processTime = round((endTime - start_time), 2)
 
             if normalize == True:

--- a/toolbox/scripts/s6_barriers.py
+++ b/toolbox/scripts/s6_barriers.py
@@ -8,7 +8,12 @@ Numpy
 """
 
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -158,7 +163,7 @@ def step6_calc_barriers():
             def do_radius_loop():
                 """Do radius loop."""
                 link_table = link_table_tmp.copy()
-                start_time = time.clock()
+                start_time = perf_counter()
                 link_loop = 0
                 pct_done = 0
                 gprint('\nMapping barriers at a radius of ' + str(radius) +

--- a/toolbox/scripts/s8_pinchpoints.py
+++ b/toolbox/scripts/s8_pinchpoints.py
@@ -8,7 +8,12 @@ Numpy
 """
 
 from os import path
-import time
+
+# Add support for Python 2. Try to import Python 3 module first.
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
 
 import numpy as npy
 import arcpy
@@ -150,7 +155,7 @@ def STEP8_calc_pinchpoints():
                     continue
                 restartFlag = False
                 lu.create_dir(linkDir)
-                start_time1 = time.clock()
+                start_time1 = perf_counter()
 
                 # source and target cores
                 corex=int(coreList[x,0])


### PR DESCRIPTION
Use time.perf_counter method when running in Python 3. time.clock was deprecated in Python 3.3 and removed in Python 3.8. 

This is a merge from https://github.com/dkav/linkage-mapper/commit/1b9666db1f38410ee30cac98c2989b74709da118 and has not been tested for this pull request.

Fixes [AttributeError: module 'time' has no attribute 'clock'](https://groups.google.com/g/linkage-mapper/c/nZPkBB8pFRk) issue raised in Google Groups. 