### PR TITLE
Resolving barrier_mapper error in s6_barriers.py line 241

### DIFF
--- a/toolbox/scripts/s6_barriers.py
+++ b/toolbox/scripts/s6_barriers.py
@@ -230,7 +230,7 @@ def step6_calc_barriers():
                         outer_radius = radius
 
                         dia = 2 * radius
-                        in_neighborhood = ("ANNULUS " + str(inner_radius)
+                        in_neighborhood = ("Annulus " + str(inner_radius)
                                            + " " + str(outer_radius) + " MAP")
 
                         @Retry(10)


### PR DESCRIPTION
Users have been experiencing an error at line 241 of s6_barriers.py, where Focal Statistics parameter was invalid. This update revises in_neighborhood on line 233 by changing capitalization of "Annulus ". The revised script runs to completion in ArcPro 3.3.2.