### PR TITLE
Fix Python 3.12, GRASS 8, and NumPy compatibility (issue #186)

### DIFF
--- a/toolbox/scripts/cc_grass_cwd.py
+++ b/toolbox/scripts/cc_grass_cwd.py
@@ -3,12 +3,22 @@
 """Create CWD and Back rasters using GRASS GIS r.walk function."""
 
 import os
+import inspect
 import subprocess
 
 import arcpy
 
 import grass.script as grass
 import grass.script.setup as gsetup
+
+# GRASS 8 dropped the gisbase positional arg from gsetup.init(); detect at
+# runtime so this works with both GRASS 7 (4 positional args) and GRASS 8
+# (3 positional args, grass_path became keyword-only).
+_GRASS8_INIT = sum(
+    1 for p in inspect.signature(gsetup.init).parameters.values()
+    if p.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                  inspect.Parameter.POSITIONAL_OR_KEYWORD)
+) < 4
 
 from cc_config import cc_env
 from lm_config import tool_env as lm_env
@@ -98,7 +108,10 @@ def setup_wrkspace(gisdbase, ccr_grassrc, geo_file):
                     "the tool (see user guide).")
         raise Exception(warn_msg)
 
-    gsetup.init(gisbase, gisdbase, location, mapset)
+    if _GRASS8_INIT:
+        gsetup.init(gisdbase, location, mapset)
+    else:
+        gsetup.init(gisbase, gisdbase, location, mapset)
     run_grass_cmd("g.gisenv", set="OVERWRITE=1")
     os.environ['GRASS_VERBOSE'] = "0"  # Only errors and warnings are printed
 

--- a/toolbox/scripts/lm_config.py
+++ b/toolbox/scripts/lm_config.py
@@ -7,7 +7,7 @@ Assigns input parameters from ToolBox to variables, and sets constants.
 """
 
 from os import path
-import imp
+import importlib.util
 import json
 
 import arcpy
@@ -23,7 +23,9 @@ def get_code_path():
 
 def set_custom(settings, config_obj):
     """Add attributes for custom file to configuration object."""
-    cust_settings = imp.load_source("set_mod", settings)
+    spec = importlib.util.spec_from_file_location("set_mod", settings)
+    cust_settings = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cust_settings)
     for setting in dir(cust_settings):
         if setting == setting.upper():
             setting_value = getattr(cust_settings, setting)

--- a/toolbox/scripts/s3_calcCwds.py
+++ b/toolbox/scripts/s3_calcCwds.py
@@ -558,16 +558,16 @@ def do_cwd_calcs(x, linkTable, coresToMap, lcpLoop, failures):
                 link = lu.get_links_from_core_pairs(linkTable,
                                                     sourceCore,
                                                     tableRow.Value)
-                if linkTable[link,cfg.LTB_LINKTYPE] > 0: # valid link
+                if link.size > 0 and linkTable[link[0],cfg.LTB_LINKTYPE] > 0: # valid link
                     linkTable[link,cfg.LTB_CWDIST] = tableRow.Min
                     if cfg.MAXCOSTDIST is not None:
                         if ((tableRow.Min > cfg.MAXCOSTDIST) and
-                           (linkTable[link,cfg.LTB_LINKTYPE] != cfg.LT_KEEP)):
+                           (linkTable[link[0],cfg.LTB_LINKTYPE] != cfg.LT_KEEP)):
                              # Disable link, it's too long
                             linkTable[link,cfg.LTB_LINKTYPE] = cfg.LT_TLLC
                     if cfg.MINCOSTDIST is not None:
                         if (tableRow.Min < cfg.MINCOSTDIST and
-                           (linkTable[link,cfg.LTB_LINKTYPE] != cfg.LT_KEEP)):
+                           (linkTable[link[0],cfg.LTB_LINKTYPE] != cfg.LT_KEEP)):
                             # Disable link, it's too short
                             linkTable[link,cfg.LTB_LINKTYPE] = cfg.LT_TSLC
             tableRow = next(tableRows)


### PR DESCRIPTION
## Summary

Fixes the three compatibility breaks that occur when running Linkage Mapper with ArcGIS Pro 3.6 (Python 3.12/3.13), a separately-installed GRASS GIS 8, and the newer NumPy bundled with Pro 3.6.

- **`lm_config.py`** — Replace `imp.load_source()` with `importlib.util`, since the `imp` module was removed in Python 3.12
- **`cc_grass_cwd.py`** — `gsetup.init()` dropped its `gisbase` positional argument in GRASS 8. Detect the installed GRASS API at runtime by counting positional parameters, so the call works with both GRASS 7 (4-arg) and GRASS 8 (3-arg) without breaking existing users
- **`s3_calcCwds.py`** — `get_links_from_core_pairs()` returns a NumPy array; newer NumPy raises `ValueError` when an array is used directly in a boolean `if` context. Guard with `link.size > 0` and use `link[0]` (scalar) for comparisons while keeping `link` (array) for assignments

All fixes are backwards-compatible with ArcGIS Pro 3.5 and earlier.

## Test plan

- [x] Confirmed `ModuleNotFoundError: No module named 'imp'` is resolved
- [x] Confirmed `init() takes from 1 to 3 positional arguments but 4 were given` is resolved with GRASS GIS 8.4
- [x] Confirmed `ValueError: The truth value of an empty array is ambiguous` is resolved in s3_calcCwds.py
- [ ] Full Climate Linkage Mapper demo run to completion (in progress)

Tested against ArcGIS Pro 3.6.3 / Python 3.13 / GRASS GIS 8.4 (separate install).

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)